### PR TITLE
Add GitHub Actions for publishing to NPM

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,31 @@
+name: Publish to NPM
+
+on:
+  push:
+    branches:
+      - production
+    paths:
+      - tsconfig/**
+
+jobs:
+  #
+
+  # # # # # # # # # # # # # # # # # # # # #
+  # # # # # # # # # # # # # # # # # # # # #
+
+  publish:
+    name: 'Publish to NPM'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Bump package version
+        working-directory: ./tsconfig
+        run: npx @helperkits/bumper bump
+
+      - name: Publish package to NPM
+        working-directory: ./tsconfig
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/tsconfig/README.md
+++ b/tsconfig/README.md
@@ -1,0 +1,3 @@
+# TSConfig
+
+This package contains the shared TypeScript configuration for the Transportes Metropolitanos de Lisboa Organization.

--- a/tsconfig/package.json
+++ b/tsconfig/package.json
@@ -1,8 +1,23 @@
 {
 	"name": "@tmlmobilidade/tsconfig",
+	"description": "Shared TypeScript configuration for the Transportes Metropolitanos de Lisboa Organization.",
 	"version": "1.0.0",
-	"private": true,
+	"license": "AGPL-3.0-or-later",
+	"homepage": "https://github.com/tmlmobilidade/tsconfig#readme",
+	"bugs": {
+		"url": "https://github.com/tmlmobilidade/tsconfig/issues"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/tmlmobilidade/tsconfig.git"
+	},
+	"keywords": [
+		"public transit",
+		"lisboa",
+		"tsconfig"
+	],
 	"publishConfig": {
 		"access": "public"
-	}
+	},
+	"main": "./base.json"
 }


### PR DESCRIPTION
This pull request adds GitHub Actions for publishing the shared TypeScript configuration package to NPM. The actions are triggered on the production branch when changes are made to the `tsconfig` directory. The package version is bumped using the `@helperkits/bumper` tool, and then the package is published to NPM with the `npm publish` command. The package includes a shared TypeScript configuration for the Transportes Metropolitanos de Lisboa Organization.